### PR TITLE
Update API documentation

### DIFF
--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -10,8 +10,10 @@ info:
       4. Click "Authorize [padlock-icon]", paste it in the "value" field, then click "Authorize".
   version: v1
 servers:
+- url: https://workspace-reservation.onrender.com
+  description: Production server
 - url: http://localhost:3000
-  description: Sandbox server for testing
+  description: Local dev server
 components:
   securitySchemes:
     bearerAuth:


### PR DESCRIPTION
I have added the URL to the production database in the API docs so that a person can test the endpoints from the documentation page online.

For review purposes, I have re-deployed the live app from this branch so that you can test the documentation [here](https://workspace-reservation.onrender.com/api-docs/index.html) as the end user would. Once approved, I will merge the changes and redeploy from `dev`.